### PR TITLE
Revert "remove format field as it was replaced with format_main_ssim"

### DIFF
--- a/solr_conf_4_testing/schema.xml
+++ b/solr_conf_4_testing/schema.xml
@@ -17,7 +17,8 @@
     <field name="all_unstem_search" type="textNoStem" indexed="true" stored="true" multiValued="true" />
     <field name="vern_all_search" type="text" indexed="true" stored="true" multiValued="true" />
 
-    <!-- Format Field is now format_main_ssim: facet and display -->
+    <!-- Format Field: facet and display -->
+    <field name="format" type="string" indexed="true" stored="true" multiValued="true" />
 
     <!-- Language Field: facet and display -->
     <field name="language" type="string" indexed="true" stored="true" multiValued="true" />

--- a/solr_conf_4_testing/solrconfig.xml
+++ b/solr_conf_4_testing/solrconfig.xml
@@ -761,6 +761,8 @@
         <str name="f.format_physical_ssim.facet.method">enum</str>
       <str name="facet.field">genre_ssim</str>
         <str name="f.genre_ssim.facet.method">enum</str>
+      <str name="facet.field">format</str>
+        <str name="f.format.facet.method">enum</str>
       <str name="facet.field">geographic_facet</str>
       <str name="facet.field">language</str>
       <str name="facet.field">pub_year_no_approx_isi</str>
@@ -786,6 +788,7 @@
         db_az_subject,
         display_type,
         file_id,
+        format,
         format_main_ssim,
         format_physical_ssim,
         genre_ssim,


### PR DESCRIPTION
This reverts commit 9ace5dd6e591a3ed4b05b993a7f0bcc67a473278.

`format` is very much still used by gdor-indexer: https://github.com/sul-dlss/gdor-indexer/blob/8ac8ae73e2de95759e477d306aaacebd525e26b3/lib/gdor/indexer.rb#L170
